### PR TITLE
made matcher settings optional

### DIFF
--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -20,7 +20,7 @@ export type ServerConfig = {
 
 export type MatcherConfig = {
   matcher: {
-    settingsURL: string;
+    settingsURL?: string;
     defaultMatcherAddress: string;
   };
 };
@@ -58,14 +58,22 @@ const load = (): DataServiceConfig => {
   // assert all necessary env vars are set
   checkEnv(envVariables);
 
+  const matcher: MatcherConfig = {
+    matcher: {
+      defaultMatcherAddress: process.env.DEFAULT_MATCHER as string,
+    },
+  };
+
+  if (
+    typeof process.env.MATCHER_SETTINGS_URL !== 'undefined' &&
+    process.env.MATCHER_SETTINGS_URL !== ''
+  ) {
+    matcher.matcher.settingsURL = process.env.MATCHER_SETTINGS_URL;
+  }
+
   return {
     ...loadDefaultConfig(),
-    matcher: {
-      settingsURL:
-        process.env.MATCHER_SETTINGS_URL ||
-        'https://matcher.wavesplatform.com/matcher/settings',
-      defaultMatcherAddress: process.env.DEFAULT_MATCHER || '',
-    },
+    ...matcher,
   };
 };
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -112,121 +112,129 @@ export default ({
   options: DataServiceConfig;
   pgDriver: PgDriver;
   emitEvent: EmitEvent;
-}): Task<AppError, ServiceMesh> =>
+}): Task<AppError, ServiceMesh> => {
+  let matcherConfig: Record<string, string> = {};
+
+  if (options.matcher.settingsURL) {
+    matcherConfig[options.matcher.defaultMatcherAddress] =
+      options.matcher.settingsURL;
+  }
+
   // @todo async init whatever is necessary
-  PairOrderingServiceImpl.create({
-    [options.matcher.defaultMatcherAddress]: options.matcher.settingsURL,
-  }).map(pairOrderingService => {
-    // caches
-    const ratesCache = new RateCacheImpl(200000, 60000); // 1 minute
-    const pairsCache = createPairsCache(1000, 5000);
-    const assetsCache = createAssetsCache(10000, 60000); // 1 minute
+  return PairOrderingServiceImpl.create(matcherConfig).map(
+    pairOrderingService => {
+      // caches
+      const ratesCache = new RateCacheImpl(200000, 60000); // 1 minute
+      const pairsCache = createPairsCache(1000, 5000);
+      const assetsCache = createAssetsCache(10000, 60000); // 1 minute
 
-    const commonDeps = {
-      drivers: {
-        pg: pgDriver,
-      },
-      emitEvent,
-    };
+      const commonDeps = {
+        drivers: {
+          pg: pgDriver,
+        },
+        emitEvent,
+      };
 
-    // common init services
-    const aliases = createAliasesService(commonDeps);
-    const assets = createAssetsService({
-      ...commonDeps,
-      cache: assetsCache,
-    });
+      // common init services
+      const aliases = createAliasesService(commonDeps);
+      const assets = createAssetsService({
+        ...commonDeps,
+        cache: assetsCache,
+      });
 
-    const aliasTxs = createAliasTxsService(commonDeps);
-    const burnTxs = createBurnTxsService(commonDeps);
-    const dataTxs = createDataTxsService(commonDeps);
-    const exchangeTxs = createExchangeTxsService(commonDeps);
-    const genesisTxs = createGenesisTxsService(commonDeps);
-    const invokeScriptTxs = createInvokeScriptTxsService(commonDeps);
-    const issueTxs = createIssueTxsService(commonDeps);
-    const leaseTxs = createLeaseTxsService(commonDeps);
-    const leaseCancelTxs = createLeaseCancelTxsService(commonDeps);
-    const massTransferTxs = createMassTransferTxsService(commonDeps);
-    const paymentTxs = createPaymentTxsService(commonDeps);
-    const reissueTxs = createReissueTxsService(commonDeps);
-    const setAssetScriptTxs = createSetAssetScriptTxsService(commonDeps);
-    const setScriptTxs = createSetScriptTxsService(commonDeps);
-    const sponsorshipTxs = createSponsorshipTxsService(commonDeps);
-    const transferTxs = createTransferTxsService(commonDeps);
-    const rates = createRateService({
-      ...commonDeps,
-      cache: ratesCache,
-    });
+      const aliasTxs = createAliasTxsService(commonDeps);
+      const burnTxs = createBurnTxsService(commonDeps);
+      const dataTxs = createDataTxsService(commonDeps);
+      const exchangeTxs = createExchangeTxsService(commonDeps);
+      const genesisTxs = createGenesisTxsService(commonDeps);
+      const invokeScriptTxs = createInvokeScriptTxsService(commonDeps);
+      const issueTxs = createIssueTxsService(commonDeps);
+      const leaseTxs = createLeaseTxsService(commonDeps);
+      const leaseCancelTxs = createLeaseCancelTxsService(commonDeps);
+      const massTransferTxs = createMassTransferTxsService(commonDeps);
+      const paymentTxs = createPaymentTxsService(commonDeps);
+      const reissueTxs = createReissueTxsService(commonDeps);
+      const setAssetScriptTxs = createSetAssetScriptTxsService(commonDeps);
+      const setScriptTxs = createSetScriptTxsService(commonDeps);
+      const sponsorshipTxs = createSponsorshipTxsService(commonDeps);
+      const transferTxs = createTransferTxsService(commonDeps);
+      const rates = createRateService({
+        ...commonDeps,
+        cache: ratesCache,
+      });
 
-    const pairsNoAsyncValidation = createPairsService({
-      ...commonDeps,
-      cache: pairsCache,
-      validatePairs: () => taskOf(undefined),
-    });
-    const pairsWithAsyncValidation = createPairsService({
-      ...commonDeps,
-      cache: pairsCache,
-      validatePairs: validatePairs(assets, pairOrderingService),
-    });
+      const pairsNoAsyncValidation = createPairsService({
+        ...commonDeps,
+        cache: pairsCache,
+        validatePairs: () => taskOf(undefined),
+      });
+      const pairsWithAsyncValidation = createPairsService({
+        ...commonDeps,
+        cache: pairsCache,
+        validatePairs: validatePairs(assets, pairOrderingService),
+      });
 
-    const candlesNoAsyncValidation = createCandlesService({
-      ...commonDeps,
-      validatePair: () => taskOf(undefined),
-    });
-    const candlesWithAsyncValidation = createCandlesService({
-      ...commonDeps,
-      validatePair: (matcher: string, pair: AssetIdsPair) =>
-        validatePairs(assets, pairOrderingService)(matcher, [pair]),
-    });
+      const candlesNoAsyncValidation = createCandlesService({
+        ...commonDeps,
+        validatePair: () => taskOf(undefined),
+      });
+      const candlesWithAsyncValidation = createCandlesService({
+        ...commonDeps,
+        validatePair: (matcher: string, pair: AssetIdsPair) =>
+          validatePairs(assets, pairOrderingService)(matcher, [pair]),
+      });
 
-    // specific init services
-    // all txs service
-    const allTxs = createAllTxsService(commonDeps)({
-      1: genesisTxs,
-      2: paymentTxs,
-      3: issueTxs,
-      4: transferTxs,
-      5: reissueTxs,
-      6: burnTxs,
-      7: exchangeTxs,
-      8: leaseTxs,
-      9: leaseCancelTxs,
-      10: aliasTxs,
-      11: massTransferTxs,
-      12: dataTxs,
-      13: setScriptTxs,
-      14: sponsorshipTxs,
-      15: setAssetScriptTxs,
-      16: invokeScriptTxs,
-    });
+      // specific init services
+      // all txs service
+      const allTxs = createAllTxsService(commonDeps)({
+        1: genesisTxs,
+        2: paymentTxs,
+        3: issueTxs,
+        4: transferTxs,
+        5: reissueTxs,
+        6: burnTxs,
+        7: exchangeTxs,
+        8: leaseTxs,
+        9: leaseCancelTxs,
+        10: aliasTxs,
+        11: massTransferTxs,
+        12: dataTxs,
+        13: setScriptTxs,
+        14: sponsorshipTxs,
+        15: setAssetScriptTxs,
+        16: invokeScriptTxs,
+      });
 
-    return {
-      aliases,
-      assets,
-      candles: candlesNoAsyncValidation,
-      pairs: pairsNoAsyncValidation,
-      transactions: {
-        all: allTxs,
-        genesis: genesisTxs,
-        payment: paymentTxs,
-        issue: issueTxs,
-        transfer: transferTxs,
-        reissue: reissueTxs,
-        burn: burnTxs,
-        exchange: exchangeTxs,
-        lease: leaseTxs,
-        leaseCancel: leaseCancelTxs,
-        alias: aliasTxs,
-        massTransfer: massTransferTxs,
-        data: dataTxs,
-        setScript: setScriptTxs,
-        sponsorship: sponsorshipTxs,
-        setAssetScript: setAssetScriptTxs,
-        invokeScript: invokeScriptTxs,
-      },
-      matchers: {
-        rates,
-        candles: candlesWithAsyncValidation,
-        pairs: pairsWithAsyncValidation,
-      },
-    };
-  });
+      return {
+        aliases,
+        assets,
+        candles: candlesNoAsyncValidation,
+        pairs: pairsNoAsyncValidation,
+        transactions: {
+          all: allTxs,
+          genesis: genesisTxs,
+          payment: paymentTxs,
+          issue: issueTxs,
+          transfer: transferTxs,
+          reissue: reissueTxs,
+          burn: burnTxs,
+          exchange: exchangeTxs,
+          lease: leaseTxs,
+          leaseCancel: leaseCancelTxs,
+          alias: aliasTxs,
+          massTransfer: massTransferTxs,
+          data: dataTxs,
+          setScript: setScriptTxs,
+          sponsorship: sponsorshipTxs,
+          setAssetScript: setAssetScriptTxs,
+          invokeScript: invokeScriptTxs,
+        },
+        matchers: {
+          rates,
+          candles: candlesWithAsyncValidation,
+          pairs: pairsWithAsyncValidation,
+        },
+      };
+    }
+  );
+};


### PR DESCRIPTION
- MATCHER_ADDRESS_URL env var became optional
- if not specified, any matcher would be considered `unknown`, so any assets order in all pairs would be allowed
- added more clear error message if MATCHER_ADDRESS_URL would be specified, but the service would not be able to load settings on launch